### PR TITLE
Improving script to create dotfiles

### DIFF
--- a/create-dotfile-links.sh
+++ b/create-dotfile-links.sh
@@ -1,6 +1,6 @@
 echo "Creating links..."
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-for f in $(find . -maxdepth 1 -type f -exec basename {} \;| grep -v "\.git" | grep "\..*") 
+for f in $(find $DIR -maxdepth 1 -type f -exec basename {} \;| grep -v "\.git" | grep "\..*") 
 do
   rm ~/$f
   ln -s $DIR/$f ~/$f

--- a/create-dotfile-links.sh
+++ b/create-dotfile-links.sh
@@ -2,6 +2,7 @@ echo "Creating links..."
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 for f in $(find $DIR -maxdepth 1 -type f -exec basename {} \;| grep -v "\.git" | grep "\..*") 
 do
+  echo "Linking ~/$f"
   rm ~/$f
   ln -s $DIR/$f ~/$f
 done

--- a/create-dotfile-links.sh
+++ b/create-dotfile-links.sh
@@ -1,7 +1,7 @@
 echo "Creating links..."
-for f in $(find ~/dotfiles | grep -v "\.git" | cut -d "/" -f5 | grep -v "^$") 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+for f in $(find . -maxdepth 1 -type f -exec basename {} \;| grep -v "\.git" | grep "\..*") 
 do
-  echo "Linking ~/$f"
   rm ~/$f
-  ln -s ~/dotfiles/$f ~/$f
+  ln -s $DIR/$f ~/$f
 done


### PR DESCRIPTION
Makes the script work from any directory, instead of relying on its path being ~/dotfiles. A bit more robust than my shitty `cut -f5` solution.
